### PR TITLE
basicpropertysupport

### DIFF
--- a/Acme.Mapper.CoreTests/ACMECoreTests.cs
+++ b/Acme.Mapper.CoreTests/ACMECoreTests.cs
@@ -53,6 +53,32 @@ namespace Acme.Mapper.CoreTests
         }
 
         [TestMethod]
+        public void MappingSimplifiedWithString()
+        {
+            var output = TestCase<JObject, JObject>(
+                mappingRules: new JObject{
+                    { systemA, "sourceproperty"} ,
+                    { systemB, "destinationproperty" } },
+                input: new JObject {
+                    { "sourceproperty", "stringvalue" } });
+
+            Assert.AreEqual("stringvalue", output["destinationproperty"].Value<string>());
+        }
+
+        [TestMethod]
+        public void MappingPartialSimplifiedWithString()
+        {
+            var output = TestCase<JObject, JObject>(
+                mappingRules: new JObject{
+                    { systemA, _property("sourceproperty")} ,
+                    { systemB, "destinationproperty" } },
+                input: new JObject {
+                    { "sourceproperty", "stringvalue" } });
+
+            Assert.AreEqual("stringvalue", output["destinationproperty"].Value<string>());
+        }
+
+        [TestMethod]
         public void MappingWithString()
         {
             var output = TestCase<JObject,JObject>(
@@ -516,6 +542,5 @@ namespace Acme.Mapper.CoreTests
                     { systemB, new JObject {{ property, "nonexistingpocoproperty"},
                         { tosubproperty, "destinationsubproperty" } } } });
         }
-
     }
 }

--- a/acmemapper/Mapper.cs
+++ b/acmemapper/Mapper.cs
@@ -177,7 +177,7 @@ namespace acmemapper
                 var mappingrules = jsonentity.Where(x =>
                     x.Value<JObject>(this.SourceSystem) != null &&
                     x.Value<JObject>(this.DestinationSystem) != null &&
-                    x.Value<JObject>(this.SourceSystem)["property"].Value<string>() == property.Key).ToList();
+                    x.Value<JObject>(this.SourceSystem)["property"].Value<string>() == property.Key);
 
                 if (mappingrules.Count() == 0)
                 {


### PR DESCRIPTION
`systemA : { "property" : "sourcefield" } `
with no extra modifier (such type/map/fromsubproperty/tosubproperty) can be now written 
`systemA : "sourcefield"`

simplifying readiness